### PR TITLE
adding support to count update mode, on this mode, the plugin counts the...

### DIFF
--- a/lib/fluent/plugin/backends/librato_backend.rb
+++ b/lib/fluent/plugin/backends/librato_backend.rb
@@ -111,6 +111,14 @@ module Fluent::MetricSenseOutput::Backends
         }
       }.to_json
 
+    METRIC_INITIALIZE_REQUEST_PER_MODE[UpdateMode::COUNT] = {
+        "type" => "gauge",
+        "attributes" => {
+          "aggregate" => false,
+          "source_aggregate" => false,
+        }
+      }.to_json
+
     def ensure_metric_initialized(http, name, mode)
       return if @initialized_metrics[name]
 

--- a/lib/fluent/plugin/out_metricsense.rb
+++ b/lib/fluent/plugin/out_metricsense.rb
@@ -210,7 +210,7 @@ module Fluent
       attr_reader :value
  
       def normalized_value(n)
-        n == 1 ? @value : @value.to_f / n
+        @value
       end
  
       def add(value)

--- a/lib/fluent/plugin/out_metricsense.rb
+++ b/lib/fluent/plugin/out_metricsense.rb
@@ -31,6 +31,7 @@ module Fluent
       ADD = 0
       MAX = 1
       AVERAGE = 2
+      COUNT = 3
     end
 
     class Backend
@@ -149,6 +150,8 @@ module Fluent
           update_mode = UpdateMode::MAX
         when "average"
           update_mode = UpdateMode::AVERAGE
+        when "count"
+          update_mode = UpdateMode::COUNT
         else
           # default is add
           update_mode = UpdateMode::ADD
@@ -195,6 +198,25 @@ module Fluent
         @value += value
       end
 
+      def mode
+        UpdateMode::ADD
+      end
+    end
+
+    class CountUpdater
+      def initialize
+        @value = 0
+      end
+      attr_reader :value
+ 
+      def normalized_value(n)
+        n == 1 ? @value : @value.to_f / n
+      end
+ 
+      def add(value)
+        @value += 1
+      end
+ 
       def mode
         UpdateMode::ADD
       end
@@ -254,6 +276,8 @@ module Fluent
           updater = MaxUpdater
         when UpdateMode::AVERAGE # AVERAGE uses MaxUpdater and calculate average on server-side aggregation
           updater = AverageUpdater
+        when UpdateMode::COUNT
+          updater = CountUpdater
         else  # default is AddUpdater
           updater = AddUpdater
         end


### PR DESCRIPTION
adding support to count update mode, on this mode, the plugin counts the amount of sources by segregation key. Usage example: request count by user
